### PR TITLE
feat: add 'old' i18n configuration

### DIFF
--- a/src/D2Shim.js
+++ b/src/D2Shim.js
@@ -2,14 +2,14 @@ import React from 'react'
 import * as PropTypes from 'prop-types'
 import { useD2 } from './useD2'
 
-export const D2Shim = ({ children, onInitialized, d2Config }) => {
-    const { d2, d2Error } = useD2({ onInitialized, d2Config })
+export const D2Shim = ({ appConfig, onInitialized, children }) => {
+    const { d2, d2Error } = useD2({ appConfig, onInitialized })
 
     return children({ d2, d2Error })
-}
+};
 
 D2Shim.propTypes = {
     onInitialized: PropTypes.func,
-    d2Config: PropTypes.object,
-    children: PropTypes.func.isRequired
+    appConfig: PropTypes.object,
+    children: PropTypes.func.isRequired,
 }

--- a/src/D2Shim.js
+++ b/src/D2Shim.js
@@ -2,8 +2,8 @@ import React from 'react'
 import * as PropTypes from 'prop-types'
 import { useD2 } from './useD2'
 
-export const D2Shim = ({ d2Config, onInitialized, i18nRoot, children }) => {
-    const { d2, d2Error } = useD2({ d2Config, onInitialized, i18nRoot })
+export const D2Shim = ({ children, onInitialized, d2Config, i18nRoot }) => {
+    const { d2, d2Error } = useD2({ onInitialized, d2Config, i18nRoot })
 
     return children({ d2, d2Error })
 }

--- a/src/D2Shim.js
+++ b/src/D2Shim.js
@@ -2,14 +2,15 @@ import React from 'react'
 import * as PropTypes from 'prop-types'
 import { useD2 } from './useD2'
 
-export const D2Shim = ({ appConfig, onInitialized, children }) => {
-    const { d2, d2Error } = useD2({ appConfig, onInitialized })
+export const D2Shim = ({ d2Config, onInitialized, i18nRoot, children }) => {
+    const { d2, d2Error } = useD2({ d2Config, onInitialized, i18nRoot })
 
     return children({ d2, d2Error })
 }
 
 D2Shim.propTypes = {
     onInitialized: PropTypes.func,
-    appConfig: PropTypes.object,
-    children: PropTypes.func.isRequired
+    d2Config: PropTypes.object,
+    children: PropTypes.func.isRequired,
+    i18nRoot: PropTypes.string
 }

--- a/src/D2Shim.js
+++ b/src/D2Shim.js
@@ -6,10 +6,10 @@ export const D2Shim = ({ appConfig, onInitialized, children }) => {
     const { d2, d2Error } = useD2({ appConfig, onInitialized })
 
     return children({ d2, d2Error })
-};
+}
 
 D2Shim.propTypes = {
     onInitialized: PropTypes.func,
     appConfig: PropTypes.object,
-    children: PropTypes.func.isRequired,
+    children: PropTypes.func.isRequired
 }

--- a/src/useD2.js
+++ b/src/useD2.js
@@ -1,27 +1,60 @@
 import { useState, useEffect } from 'react'
-import { init as initD2 } from 'd2'
+import { init as d2Init, config as d2Config, getUserSettings } from 'd2'
 import { useConfig } from '@dhis2/app-runtime'
 
 let theD2 = null
 
-export const useD2 = ({ d2Config = {}, onInitialized = () => {} }) => {
-    const { baseUrl, apiVersion } = useConfig()
-    const [d2, setD2] = useState(theD2)
-    const [d2Error, setError] = useState(undefined)
+const configI18n = async (baseUrl, i18nRoot) => {
+  d2Config.baseUrl = baseUrl
 
-    useEffect(() => {
-        if (!theD2) {
-            initD2({
-                appUrl: baseUrl,
-                baseUrl: `${baseUrl}/api/${apiVersion}`,
-                ...d2Config
-            }).then(async d2 => {
-                await onInitialized(d2)
-                theD2 = d2
-                setD2(d2)
-            }).catch(setError)
-        }
-    }, [])
+  const settings = await getUserSettings()
 
-    return { d2, d2Error } // d2 is null while loading
+  if (settings.keyUiLocale && settings.keyUiLocale !== 'en') {
+    await d2Config.i18n.sources.add(
+      `${i18nRoot}/i18n_module_${settings.keyUiLocale}.properties`
+    )
+  }
+
+  await d2Config.i18n.sources.add('${i18nRoot}/i18n_module_en.properties')
+}
+
+const init = async ({ appUrl, baseUrl, appConfig }) => {
+  const { i18nRoot, ...initConfig } = appConfig
+
+  if (i18nRoot) {
+    await configI18n(baseUrl, i18nRoot)
+  }
+
+  return await d2Init({
+    appUrl,
+    baseUrl,
+    ...initConfig,
+  })
+}
+
+export const useD2 = ({
+  appConfig = {},
+  onInitialized = Function.prototype,
+}) => {
+  const { baseUrl, apiVersion } = useConfig()
+  const [d2, setD2] = useState(theD2)
+  const [d2Error, setError] = useState(undefined)
+
+  useEffect(() => {
+    if (!theD2) {
+      init({
+        appUrl: baseUrl,
+        baseUrl: `${baseUrl}/api/${apiVersion}`,
+        appConfig,
+      })
+        .then(async (d2) => {
+          await onInitialized(d2)
+          theD2 = d2
+          setD2(d2)
+        })
+        .catch(setError)
+    }
+  }, [])
+
+  return { d2, d2Error } // d2 is null while loading
 }

--- a/src/useD2.js
+++ b/src/useD2.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { init as d2Init, config as d2Config, getUserSettings } from 'd2'
+import { init as initD2, config as d2Config, getUserSettings } from 'd2'
 import { useConfig } from '@dhis2/app-runtime'
 
 let theD2 = null
@@ -25,7 +25,7 @@ const init = async ({ appUrl, baseUrl, appConfig }) => {
     await configI18n(baseUrl, i18nRoot)
   }
 
-  return await d2Init({
+  return await initD2({
     appUrl,
     baseUrl,
     ...initConfig,

--- a/src/useD2.js
+++ b/src/useD2.js
@@ -10,12 +10,12 @@ const configI18n = async (baseUrl, i18nRoot) => {
   const settings = await getUserSettings()
 
   if (settings.keyUiLocale && settings.keyUiLocale !== 'en') {
-    await config.i18n.sources.add(
+    config.i18n.sources.add(
       `${i18nRoot}/i18n_module_${settings.keyUiLocale}.properties`
     )
   }
 
-  await config.i18n.sources.add('${i18nRoot}/i18n_module_en.properties')
+  config.i18n.sources.add('${i18nRoot}/i18n_module_en.properties')
 }
 
 const init = async ({ appUrl, baseUrl, d2Config, i18nRoot = null }) => {


### PR DESCRIPTION
Add optional config param to allow configuring the old i18n translations (.properties files). The value of i18nRoot should be the relative root directory where the old i18n files are stored