### PR TITLE
fix: make useD2 argument optional

### DIFF
--- a/src/__tests__/D2Shim.spec.js
+++ b/src/__tests__/D2Shim.spec.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-import-assign,import/namespace */
+
 import React from 'react'
 import { D2Shim } from '../D2Shim'
 import { render } from '@testing-library/react'

--- a/src/useD2.js
+++ b/src/useD2.js
@@ -34,7 +34,7 @@ export const useD2 = ({
     d2Config = {},
     onInitialized = Function.prototype,
     i18nRoot,
-}) => {
+} = {}) => {
     const { baseUrl, apiVersion } = useConfig()
     const [d2, setD2] = useState(theD2)
     const [d2Error, setError] = useState(undefined)


### PR DESCRIPTION
I noticed when working in `dashboard-app` that the `useD2` hook requires an object be passed as `arguments[0]`, even if that object is empty.  It's cleaner to set a default empty object so that it can be `useD2()` instead of `useD2({})`