### PR TITLE
feat: allow to pass locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
         "react-test-renderer": "^16.8"
     },
     "dependencies": {
-        "@dhis2/ui-core": "^4.6.1",
         "prop-types": "^15.7.2"
     },
     "peerDependencies": {

--- a/src/D2Shim.js
+++ b/src/D2Shim.js
@@ -1,8 +1,8 @@
 import * as PropTypes from 'prop-types'
 import { useD2 } from './useD2'
 
-export const D2Shim = ({ children, onInitialized, d2Config, i18nRoot }) => {
-    const { d2, d2Error } = useD2({ onInitialized, d2Config, i18nRoot })
+export const D2Shim = ({ children, onInitialized, d2Config, i18nRoot, locale }) => {
+    const { d2, d2Error } = useD2({ onInitialized, d2Config, i18nRoot, locale })
 
     return children({ d2, d2Error })
 }
@@ -11,5 +11,6 @@ D2Shim.propTypes = {
     children: PropTypes.func.isRequired,
     d2Config: PropTypes.object,
     i18nRoot: PropTypes.string,
+    locale: PropTypes.string,
     onInitialized: PropTypes.func,
 }

--- a/src/__tests__/useD2-with-locale.spec.js
+++ b/src/__tests__/useD2-with-locale.spec.js
@@ -13,7 +13,7 @@ jest.mock('@dhis2/app-runtime', () => {
     }
 })
 
-describe('useD2', () => {
+describe('useD2 with locale', () => {
     it('sets the language from the given locale', async () => {
         const initSpy = jest.spyOn(alld2, 'init').mockResolvedValue('d2obj')
         const userSettingsSpy = jest

--- a/src/__tests__/useD2-with-locale.spec.js
+++ b/src/__tests__/useD2-with-locale.spec.js
@@ -1,0 +1,41 @@
+import { renderHook } from '@testing-library/react-hooks'
+import * as alld2 from 'd2'
+import { useD2 } from '../useD2'
+
+jest.mock('@dhis2/app-runtime', () => {
+    return {
+        useConfig: () => {
+            return {
+                baseUrl: 'baseurl',
+                apiVersion: '42',
+            }
+        },
+    }
+})
+
+describe('useD2', () => {
+    it('sets the language from the given locale', async () => {
+        const initSpy = jest.spyOn(alld2, 'init').mockResolvedValue('d2obj')
+        const userSettingsSpy = jest
+            .spyOn(alld2, 'getUserSettings')
+            .mockResolvedValue({
+                keyUiLocale: 'no',
+            })
+        const spy = jest.spyOn(alld2.config.i18n.sources, 'add')
+        const { waitForNextUpdate } = renderHook(() =>
+            useD2({
+                d2Config: { schemas: ['schema1'] },
+                i18nRoot: 'i18n_old',
+                locale: 'it',
+            })
+        )
+
+        await waitForNextUpdate()
+
+        expect(userSettingsSpy).toHaveBeenCalledTimes(0)
+
+        expect(spy).toHaveBeenCalledWith('i18n_old/i18n_module_it.properties')
+
+        jest.restoreAllMocks()
+    })
+})

--- a/src/__tests__/useD2.spec.js
+++ b/src/__tests__/useD2.spec.js
@@ -59,30 +59,4 @@ describe('useD2', () => {
 
         jest.restoreAllMocks()
     })
-
-    it.skip('sets the language from the given locale', async () => {
-        const initSpy = jest.spyOn(alld2, 'init').mockResolvedValue('d2obj')
-        const userSettingsSpy = jest
-            .spyOn(alld2, 'getUserSettings')
-            .mockResolvedValue({
-                keyUiLocale: 'no',
-            })
-        const spy = jest.spyOn(alld2.config.i18n.sources, 'add')
-
-        const { result, waitForNextUpdate } = renderHook(() =>
-            useD2({
-                d2Config: { schemas: ['schema1'] },
-                i18nRoot: 'i18n_old',
-                locale: 'it',
-            })
-        )
-
-        await waitForNextUpdate()
-
-        expect(userSettingsSpy).toHaveBeenCalledTimes(0)
-
-        expect(spy).toHaveBeenCalledWith('i18n_old/i18n_module_it.properties')
-
-        jest.restoreAllMocks()
-    })
 })

--- a/src/__tests__/useD2.spec.js
+++ b/src/__tests__/useD2.spec.js
@@ -16,9 +16,11 @@ jest.mock('@dhis2/app-runtime', () => {
 describe('useD2', () => {
     it('returns the d2 config and sets the language', async () => {
         const initSpy = jest.spyOn(alld2, 'init').mockResolvedValue('d2obj')
-        jest.spyOn(alld2, 'getUserSettings').mockResolvedValue({
-            keyUiLocale: 'no',
-        })
+        const userSettingsSpy = jest
+            .spyOn(alld2, 'getUserSettings')
+            .mockResolvedValue({
+                keyUiLocale: 'no',
+            })
         const spy = jest.spyOn(alld2.config.i18n.sources, 'add')
         const mockOnInit = jest.fn().mockResolvedValue('initialized')
 
@@ -51,7 +53,35 @@ describe('useD2', () => {
             schemas: ['schema1'],
         })
 
+        expect(userSettingsSpy).toHaveBeenCalledTimes(1)
+
         expect(spy).toHaveBeenCalledWith('i18n_old/i18n_module_no.properties')
+
+        jest.restoreAllMocks()
+    })
+
+    it.skip('sets the language from the given locale', async () => {
+        const initSpy = jest.spyOn(alld2, 'init').mockResolvedValue('d2obj')
+        const userSettingsSpy = jest
+            .spyOn(alld2, 'getUserSettings')
+            .mockResolvedValue({
+                keyUiLocale: 'no',
+            })
+        const spy = jest.spyOn(alld2.config.i18n.sources, 'add')
+
+        const { result, waitForNextUpdate } = renderHook(() =>
+            useD2({
+                d2Config: { schemas: ['schema1'] },
+                i18nRoot: 'i18n_old',
+                locale: 'it',
+            })
+        )
+
+        await waitForNextUpdate()
+
+        expect(userSettingsSpy).toHaveBeenCalledTimes(0)
+
+        expect(spy).toHaveBeenCalledWith('i18n_old/i18n_module_it.properties')
 
         jest.restoreAllMocks()
     })

--- a/src/useD2.js
+++ b/src/useD2.js
@@ -7,14 +7,12 @@ let theD2 = null
 const configI18n = async (baseUrl, i18nRoot, locale) => {
     config.baseUrl = baseUrl
 
-    if (!locale) {
-        const settings = await getUserSettings()
+    const currentLocale = locale || (await getUserSettings()).keyUiLocale
 
-        locale = settings.keyUiLocale
-    }
-
-    if (locale && locale !== 'en') {
-        config.i18n.sources.add(`${i18nRoot}/i18n_module_${locale}.properties`)
+    if (currentLocale && currentLocale !== 'en') {
+        config.i18n.sources.add(
+            `${i18nRoot}/i18n_module_${currentLocale}.properties`
+        )
     }
 
     config.i18n.sources.add(`${i18nRoot}/i18n_module_en.properties`)

--- a/src/useD2.js
+++ b/src/useD2.js
@@ -4,23 +4,31 @@ import { useConfig } from '@dhis2/app-runtime'
 
 let theD2 = null
 
-const configI18n = async (baseUrl, i18nRoot) => {
+const configI18n = async (baseUrl, i18nRoot, locale) => {
     config.baseUrl = baseUrl
 
-    const settings = await getUserSettings()
+    if (!locale) {
+        const settings = await getUserSettings()
 
-    if (settings.keyUiLocale && settings.keyUiLocale !== 'en') {
-        config.i18n.sources.add(
-            `${i18nRoot}/i18n_module_${settings.keyUiLocale}.properties`
-        )
+        locale = settings.keyUiLocale
+    }
+
+    if (locale && locale !== 'en') {
+        config.i18n.sources.add(`${i18nRoot}/i18n_module_${locale}.properties`)
     }
 
     config.i18n.sources.add(`${i18nRoot}/i18n_module_en.properties`)
 }
 
-const initD2 = async ({ appUrl, baseUrl, d2Config, i18nRoot = null }) => {
+const initD2 = async ({
+    appUrl,
+    baseUrl,
+    d2Config,
+    i18nRoot = null,
+    locale,
+}) => {
     if (i18nRoot) {
-        await configI18n(baseUrl, i18nRoot)
+        await configI18n(baseUrl, i18nRoot, locale)
     }
 
     return await init({
@@ -34,6 +42,7 @@ export const useD2 = ({
     d2Config = {},
     onInitialized = Function.prototype,
     i18nRoot,
+    locale,
 } = {}) => {
     const { baseUrl, apiVersion } = useConfig()
     const [d2, setD2] = useState(theD2)
@@ -46,6 +55,7 @@ export const useD2 = ({
                 baseUrl: `${baseUrl}/api/${apiVersion}`,
                 d2Config,
                 i18nRoot,
+                locale,
             })
                 .then(async d2 => {
                     await onInitialized(d2)


### PR DESCRIPTION
This is to avoid yet another request for user settings.
Typically apps do that already as they need some user setting, in that case they can pass the locale directly to `D2Shim` for the i18n initialisation, thus avoiding the same request done by the shim.

**Note**: the test I added fails when run together with the existing one, that's why I used `it.skip` on it.
I'm not sure why the failure happens, help appreciated.